### PR TITLE
Analyze heatmap logic and color gradients

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { MapProvider, useMapContext } from './context/MapContext';
 import { MapContainer } from './components/Map';
 import { PropertyListView } from './components/PropertyList';
-import { ParameterSelector } from './components/Controls';
+import { ParameterSelector, CalloutToggle } from './components/Controls';
 import { ErrorBoundary } from './components/common';
 import { testProperties } from './data/testProperties';
 import { usePropertyData } from './hooks';
@@ -31,6 +31,8 @@ function AppContent() {
                             <div className="text-sm text-gray-500">
                                 {filteredProperties.length} properties
                             </div>
+                            {/* Callout Toggle */}
+                            <CalloutToggle />
                             {/* Parameter Filter - Top Right */}
                             <div className="w-64">
                                 <ParameterSelector />

--- a/src/components/Controls/ColorLegend.tsx
+++ b/src/components/Controls/ColorLegend.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Property } from '../../types';
-import { getColorScaleForParameter, formatParameterValue } from '../../utils';
+import { getColorScaleForParameter, formatParameterValue, getParameterDisplayName } from '../../utils';
 import { useMapContext } from '../../context/MapContext';
 
 interface ColorLegendProps {
@@ -13,7 +13,9 @@ export function ColorLegend({ properties, className = '' }: ColorLegendProps) {
 
     if (properties.length === 0) return null;
 
-    const colorScale = getColorScaleForParameter(properties, state.viewConfig.colorParameter);
+    // For cross-parameter logic: color is based on the opposite parameter
+    const colorParameter = state.viewConfig.colorParameter === 'availableSF' ? 'askingRate' : 'availableSF';
+    const colorScale = getColorScaleForParameter(properties, colorParameter);
 
     // Create gradient stops
     const gradientStops = [
@@ -24,23 +26,14 @@ export function ColorLegend({ properties, className = '' }: ColorLegendProps) {
         { offset: '100%', color: colorScale.getColor(colorScale.max) }
     ];
 
-    const getParameterDisplayName = (parameter: typeof state.viewConfig.colorParameter) => {
-        switch (parameter) {
-            case 'askingRate':
-                return 'Asking Rate';
-            case 'availableSF':
-                return 'Available SF';
-            case 'rba':
-                return 'Rentable Building Area';
-            default:
-                return parameter;
-        }
-    };
+    // Get display names for both parameters
+    const selectedParameterName = getParameterDisplayName(state.viewConfig.colorParameter);
+    const colorParameterName = getParameterDisplayName(colorParameter);
 
     return (
         <div className={`bg-white border border-gray-200 rounded-lg p-4 ${className}`}>
             <h3 className="text-sm font-medium text-gray-900 mb-3">
-                {getParameterDisplayName(state.viewConfig.colorParameter)} Scale
+                Color Scale: {colorParameterName}
             </h3>
 
             <div className="space-y-3">
@@ -56,13 +49,14 @@ export function ColorLegend({ properties, className = '' }: ColorLegendProps) {
 
                 {/* Scale labels */}
                 <div className="flex justify-between text-xs text-gray-600">
-                    <span>{formatParameterValue(colorScale.min, state.viewConfig.colorParameter)}</span>
-                    <span>{formatParameterValue(colorScale.max, state.viewConfig.colorParameter)}</span>
+                    <span>{formatParameterValue(colorScale.min, colorParameter)}</span>
+                    <span>{formatParameterValue(colorScale.max, colorParameter)}</span>
                 </div>
 
                 {/* Legend description */}
                 <div className="text-xs text-gray-500">
-                    <p>Red indicates lower values, green indicates higher values</p>
+                    <p>Marker size based on {selectedParameterName}</p>
+                    <p>Color based on {colorParameterName} (Red = lower, Green = higher)</p>
                 </div>
             </div>
         </div>

--- a/src/components/Controls/ParameterSelector.tsx
+++ b/src/components/Controls/ParameterSelector.tsx
@@ -10,7 +10,7 @@ interface ParameterSelectorProps {
 export function ParameterSelector({ className = '' }: ParameterSelectorProps) {
     const { state, updateViewConfig } = useMapContext();
 
-    const parameters: ColorParameter[] = ['askingRate', 'availableSF', 'rba'];
+    const parameters: ColorParameter[] = ['askingRate', 'availableSF'];
 
     const handleParameterChange = (parameter: ColorParameter) => {
         updateViewConfig({ colorParameter: parameter });

--- a/src/components/Map/MapContainer.example.tsx
+++ b/src/components/Map/MapContainer.example.tsx
@@ -169,7 +169,7 @@ export function MapContainerExample() {
                         </div>
                         <div>
                             <span className="font-medium text-gray-700">Asking Rate:</span>
-                            <p className="text-gray-600">${selectedProperty.askingRate}/SF/year</p>
+                            <p className="text-gray-600">${selectedProperty.askingRate}/SF</p>
                         </div>
                         <div>
                             <span className="font-medium text-gray-700">Available SF:</span>

--- a/src/components/Map/MapContainer.tsx
+++ b/src/components/Map/MapContainer.tsx
@@ -208,10 +208,6 @@ export function MapContainer({
             })}
 
 
-            {/* Callout Toggle */}
-            <div className="absolute top-4 right-4 z-50">
-                <CalloutToggle />
-            </div>
         </div>
     );
 }

--- a/src/components/Map/PropertyCalloutOverlay.tsx
+++ b/src/components/Map/PropertyCalloutOverlay.tsx
@@ -205,7 +205,7 @@ export class PropertyCalloutOverlay {
         const askingRateInfo = {
             label: 'Asking Rate',
             value: this.property.askingRate > 0
-                ? `$${this.property.askingRate.toFixed(2)}/SF/yr`
+                ? `$${this.property.askingRate.toFixed(2)}/SF`
                 : 'N/A'
         };
 

--- a/src/components/Map/PropertyCalloutOverlay.tsx
+++ b/src/components/Map/PropertyCalloutOverlay.tsx
@@ -151,9 +151,9 @@ export class PropertyCalloutOverlay {
             const pixelX = (worldCoordinate.x - swPoint.x) / (nePoint.x - swPoint.x) * mapWidth;
             const pixelY = (worldCoordinate.y - nePoint.y) / (swPoint.y - nePoint.y) * mapHeight;
 
-            // Position the callout
-            const calloutWidth = 170;
-            const calloutHeight = 60;
+            // Position the callout (increased height for two parameters)
+            const calloutWidth = 180;
+            const calloutHeight = 80;
 
             let left = pixelX - (calloutWidth / 2);
             let top = pixelY - calloutHeight - 10;
@@ -194,46 +194,28 @@ export class PropertyCalloutOverlay {
 
     updateColorParameter(colorParameter: ColorParameter) {
         this.colorParameter = colorParameter;
-        if (this.div) {
-            this.renderCallout(); // Re-render with new parameter
-        }
+        // No need to re-render since we always show both parameters
+        // Keeping this method for consistency with existing API
     }
 
     private renderCallout() {
         if (!this.div) return;
 
-        // Get the parameter label and value
-        const getParameterInfo = () => {
-            switch (this.colorParameter) {
-                case 'askingRate':
-                    return {
-                        label: 'Asking Rate',
-                        value: this.property.askingRate > 0
-                            ? new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(this.property.askingRate)
-                            : 'N/A'
-                    };
-                case 'availableSF':
-                    return {
-                        label: 'Available SF',
-                        value: new Intl.NumberFormat('en-US').format(this.property.availableSF) + ' SF'
-                    };
-                case 'rba':
-                    return {
-                        label: 'RBA',
-                        value: new Intl.NumberFormat('en-US').format(this.property.rba) + ' SF'
-                    };
-                default:
-                    return {
-                        label: 'Available SF',
-                        value: new Intl.NumberFormat('en-US').format(this.property.availableSF) + ' SF'
-                    };
-            }
+        // Always show both parameters
+        const askingRateInfo = {
+            label: 'Asking Rate',
+            value: this.property.askingRate > 0
+                ? `$${this.property.askingRate.toFixed(2)}/SF/yr`
+                : 'N/A'
         };
 
-        const paramInfo = getParameterInfo();
+        const availableSFInfo = {
+            label: 'Available SF',
+            value: new Intl.NumberFormat('en-US').format(this.property.availableSF) + ' SF'
+        };
 
         this.div.innerHTML = `
-            <div style="background: white; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); border: 1px solid #e5e7eb; padding: 8px 12px; min-width: 140px; max-width: 200px; position: relative; font-family: system-ui, -apple-system, sans-serif;">
+            <div style="background: white; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); border: 1px solid #e5e7eb; padding: 8px 12px; min-width: 160px; max-width: 220px; position: relative; font-family: system-ui, -apple-system, sans-serif;">
                 <!-- Arrow pointing down -->
                 <div style="position: absolute; bottom: 0; left: 50%; transform: translate(-50%, 100%);">
                     <div style="width: 0; height: 0; border-left: 6px solid transparent; border-right: 6px solid transparent; border-top: 6px solid white;"></div>
@@ -243,15 +225,23 @@ export class PropertyCalloutOverlay {
                 </div>
 
                 <!-- Property name -->
-                <div style="font-weight: 600; color: #111827; font-size: 13px; line-height: 1.2; margin-bottom: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                <div style="font-weight: 600; color: #111827; font-size: 13px; line-height: 1.2; margin-bottom: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
                     ${this.property.name}
                 </div>
 
-                <!-- Parameter value -->
-                <div style="display: flex; justify-content: space-between; align-items: center;">
-                    <span style="font-size: 11px; font-weight: 500; color: #6b7280;">${paramInfo.label}:</span>
+                <!-- Asking Rate -->
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 3px;">
+                    <span style="font-size: 11px; font-weight: 500; color: #6b7280;">${askingRateInfo.label}:</span>
                     <span style="font-size: 12px; font-weight: 600; color: #111827;">
-                        ${paramInfo.value}
+                        ${askingRateInfo.value}
+                    </span>
+                </div>
+
+                <!-- Available SF -->
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                    <span style="font-size: 11px; font-weight: 500; color: #6b7280;">${availableSFInfo.label}:</span>
+                    <span style="font-size: 12px; font-weight: 600; color: #111827;">
+                        ${availableSFInfo.value}
                     </span>
                 </div>
             </div>

--- a/src/components/Map/PropertyMarker.tsx
+++ b/src/components/Map/PropertyMarker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Property } from '../../types';
-import { getPropertyColor, getColorScaleForParameter, getLighterColor, getPropertyColorCrossParameter } from '../../utils';
+import { getLighterColor, getPropertyColorCrossParameter, getNormalizedMarkerSize } from '../../utils';
 import { useMapContext } from '../../context/MapContext';
 import { PropertyCalloutOverlay } from './PropertyCalloutOverlay';
 
@@ -46,50 +46,22 @@ export function PropertyMarker({ property, map, allProperties, clientPropertyId 
         if (!map) return;
 
         // Get color and size for the marker using cross-parameter logic
-        const parameterValue = state.viewConfig.colorParameter === 'askingRate' ? property.askingRate : property.availableSF;
         const markerColor = getPropertyColorCrossParameter(property, state.viewConfig.colorParameter, allProperties);
-
-        // Calculate size relative to client property
-        const isClientProperty = property.id === clientPropertyId;
-        const clientProperty = allProperties.find(p => p.id === clientPropertyId);
-        let markerSize = 30; // Default fallback size
-
-        if (isClientProperty) {
-            // Client property gets fixed baseline size
-            markerSize = 40;
-        } else if (clientProperty) {
-            // Calculate size relative to client property value
-            const clientValue = state.viewConfig.colorParameter === 'askingRate' ? clientProperty.askingRate : clientProperty.availableSF;
-
-            const clientBaseSize = 40; // Client property baseline size
-            const ratio = parameterValue / clientValue;
-
-            // Calculate proportional size with reasonable bounds
-            const minSize = 10;  // Minimum visible size
-            const maxSize = 120; // Maximum reasonable size
-
-            // Direct proportional scaling: if property is 2x client value, marker is 2x client size
-            const proportionalSize = clientBaseSize * ratio;
-
-            // Clamp to reasonable bounds but maintain proportionality
-            markerSize = Math.max(minSize, Math.min(maxSize, proportionalSize));
-
-            console.log(`Size calculation for ${property.name}:
-                Client value: ${clientValue}
-                Property value: ${parameterValue}  
-                Ratio: ${ratio.toFixed(2)}x
-                Proportional size: ${proportionalSize.toFixed(1)}px
-                Final size: ${markerSize.toFixed(1)}px`);
-        } else {
-            // Fallback if no client property found
-            markerSize = 30;
-        }
+        
+        // Use normalized sizing for consistent scaling across parameters
+        const markerSize = getNormalizedMarkerSize(
+            property,
+            state.viewConfig.colorParameter,
+            allProperties,
+            clientPropertyId
+        );
 
         // Apply minimal offset for overlapping markers (just enough to see all)
         const offsetCoords = calculateMinimalOffset(property, allProperties);
         const markerPosition = new google.maps.LatLng(offsetCoords.lat, offsetCoords.lng);
 
         // Create marker with appropriate icon and proper anchoring
+        const isClientProperty = property.id === clientPropertyId;
         let marker;
         if (isClientProperty) {
             // For client property: Create two markers - circle background + star foreground
@@ -184,31 +156,17 @@ export function PropertyMarker({ property, map, allProperties, clientPropertyId 
     // Update marker appearance when parameter changes or selection state changes
     useEffect(() => {
         if (markerRef.current && map) {
-            const parameterValue = state.viewConfig.colorParameter === 'askingRate' ? property.askingRate : property.availableSF;
             const markerColor = getPropertyColorCrossParameter(property, state.viewConfig.colorParameter, allProperties);
+            
+            // Use normalized sizing for consistent scaling across parameters
+            const markerSize = getNormalizedMarkerSize(
+                property,
+                state.viewConfig.colorParameter,
+                allProperties,
+                clientPropertyId
+            );
 
             const isClientProperty = property.id === clientPropertyId;
-            const clientProperty = allProperties.find(p => p.id === clientPropertyId);
-            let markerSize = 30; // Default fallback size
-
-            if (isClientProperty) {
-                markerSize = 40;
-            } else if (clientProperty) {
-                const clientValue = state.viewConfig.colorParameter === 'askingRate' ? clientProperty.askingRate : clientProperty.availableSF;
-
-                const clientBaseSize = 40; // Client property baseline size
-                const ratio = parameterValue / clientValue;
-
-                // Calculate proportional size with reasonable bounds
-                const minSize = 10;  // Minimum visible size
-                const maxSize = 120; // Maximum reasonable size
-
-                // Direct proportional scaling: if property is 2x client value, marker is 2x client size
-                const proportionalSize = clientBaseSize * ratio;
-
-                // Clamp to reasonable bounds but maintain proportionality
-                markerSize = Math.max(minSize, Math.min(maxSize, proportionalSize));
-            }
 
             if (isClientProperty) {
                 // Update star marker

--- a/src/components/Map/PropertyMarker.tsx
+++ b/src/components/Map/PropertyMarker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Property } from '../../types';
-import { getPropertyColor, getColorScaleForParameter, getLighterColor } from '../../utils';
+import { getPropertyColor, getColorScaleForParameter, getLighterColor, getPropertyColorCrossParameter } from '../../utils';
 import { useMapContext } from '../../context/MapContext';
 import { PropertyCalloutOverlay } from './PropertyCalloutOverlay';
 
@@ -45,11 +45,9 @@ export function PropertyMarker({ property, map, allProperties, clientPropertyId 
     useEffect(() => {
         if (!map) return;
 
-        // Get color and size for the marker
-        const colorScale = getColorScaleForParameter(allProperties, state.viewConfig.colorParameter);
-        const parameterValue = state.viewConfig.colorParameter === 'askingRate' ? property.askingRate :
-            state.viewConfig.colorParameter === 'availableSF' ? property.availableSF : property.rba;
-        const markerColor = getPropertyColor(property, state.viewConfig.colorParameter, colorScale);
+        // Get color and size for the marker using cross-parameter logic
+        const parameterValue = state.viewConfig.colorParameter === 'askingRate' ? property.askingRate : property.availableSF;
+        const markerColor = getPropertyColorCrossParameter(property, state.viewConfig.colorParameter, allProperties);
 
         // Calculate size relative to client property
         const isClientProperty = property.id === clientPropertyId;
@@ -61,8 +59,7 @@ export function PropertyMarker({ property, map, allProperties, clientPropertyId 
             markerSize = 40;
         } else if (clientProperty) {
             // Calculate size relative to client property value
-            const clientValue = state.viewConfig.colorParameter === 'askingRate' ? clientProperty.askingRate :
-                state.viewConfig.colorParameter === 'availableSF' ? clientProperty.availableSF : clientProperty.rba;
+            const clientValue = state.viewConfig.colorParameter === 'askingRate' ? clientProperty.askingRate : clientProperty.availableSF;
 
             const clientBaseSize = 40; // Client property baseline size
             const ratio = parameterValue / clientValue;
@@ -187,17 +184,8 @@ export function PropertyMarker({ property, map, allProperties, clientPropertyId 
     // Update marker appearance when parameter changes or selection state changes
     useEffect(() => {
         if (markerRef.current && map) {
-            const colorScale = getColorScaleForParameter(
-                allProperties,
-                state.viewConfig.colorParameter
-            );
-            const parameterValue = state.viewConfig.colorParameter === 'askingRate' ? property.askingRate :
-                state.viewConfig.colorParameter === 'availableSF' ? property.availableSF : property.rba;
-            const markerColor = getPropertyColor(
-                property,
-                state.viewConfig.colorParameter,
-                colorScale
-            );
+            const parameterValue = state.viewConfig.colorParameter === 'askingRate' ? property.askingRate : property.availableSF;
+            const markerColor = getPropertyColorCrossParameter(property, state.viewConfig.colorParameter, allProperties);
 
             const isClientProperty = property.id === clientPropertyId;
             const clientProperty = allProperties.find(p => p.id === clientPropertyId);
@@ -206,8 +194,7 @@ export function PropertyMarker({ property, map, allProperties, clientPropertyId 
             if (isClientProperty) {
                 markerSize = 40;
             } else if (clientProperty) {
-                const clientValue = state.viewConfig.colorParameter === 'askingRate' ? clientProperty.askingRate :
-                    state.viewConfig.colorParameter === 'availableSF' ? clientProperty.availableSF : clientProperty.rba;
+                const clientValue = state.viewConfig.colorParameter === 'askingRate' ? clientProperty.askingRate : clientProperty.availableSF;
 
                 const clientBaseSize = 40; // Client property baseline size
                 const ratio = parameterValue / clientValue;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,7 @@ export interface Property {
 /**
  * Available parameters for color-coding properties on the map
  */
-export type ColorParameter = 'askingRate' | 'availableSF' | 'rba';
+export type ColorParameter = 'askingRate' | 'availableSF';
 
 /**
  * Configuration for map view settings and display options

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,7 +34,7 @@ export interface Property {
     /** Available square footage for lease */
     availableSF: number;
 
-    /** Asking rental rate in dollars per square foot per year */
+    /** Asking rental rate in dollars per square foot */
     askingRate: number;
 
     /** Building classification grade (A, B, or C) */

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -10,7 +10,7 @@ This module provides comprehensive utilities for calculating marker colors based
 
 ## 📊 Supported Parameters
 
-- `askingRate`: Rental rate per square foot per year
+- `askingRate`: Rental rate per square foot
 - `availableSF`: Available square footage for lease
 - `rba`: Rentable Building Area
 

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -271,7 +271,7 @@ function interpolateColor(color1: string, color2: string, ratio: number): string
 export function formatParameterValue(value: number, parameter: ColorParameter): string {
     switch (parameter) {
         case 'askingRate':
-            return `$${value.toFixed(2)}/SF/year`;
+            return `$${value.toFixed(2)}/SF`;
         case 'availableSF':
             return `${value.toLocaleString()} SF`;
         default:

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -55,8 +55,6 @@ export function getColorScaleForParameter(
                 return prop.askingRate;
             case 'availableSF':
                 return prop.availableSF;
-            case 'rba':
-                return prop.rba;
             default:
                 return 0;
         }
@@ -86,9 +84,6 @@ export function getPropertyColor(
         case 'availableSF':
             value = property.availableSF;
             break;
-        case 'rba':
-            value = property.rba;
-            break;
         default:
             value = 0;
     }
@@ -108,10 +103,6 @@ export function getPropertyColor(
             // Red = More available space (competitive threat), Green = Less available space
             colorPosition = 1 - normalizedValue; // Invert so higher values are red
             break;
-        case 'rba':
-            // Red = Larger building (competitive advantage), Green = Smaller building
-            colorPosition = 1 - normalizedValue; // Invert so higher values are red
-            break;
         default:
             colorPosition = normalizedValue;
     }
@@ -121,6 +112,26 @@ export function getPropertyColor(
 
     // Convert to red-green gradient
     return getRedGreenGradientColor(colorPosition);
+}
+
+/**
+ * Gets the color for a property using cross-parameter logic
+ * If selectedParameter is 'availableSF', color is based on 'askingRate'
+ * If selectedParameter is 'askingRate', color is based on 'availableSF'
+ */
+export function getPropertyColorCrossParameter(
+    property: Property,
+    selectedParameter: ColorParameter,
+    properties: Property[]
+): string {
+    // Determine which parameter to use for coloring (opposite of selected)
+    const colorParameter: ColorParameter = selectedParameter === 'availableSF' ? 'askingRate' : 'availableSF';
+    
+    // Get color scale for the color parameter
+    const colorScale = getColorScaleForParameter(properties, colorParameter);
+    
+    // Get the color using the cross-parameter
+    return getPropertyColor(property, colorParameter, colorScale);
 }
 
 /**
@@ -184,7 +195,6 @@ export function formatParameterValue(value: number, parameter: ColorParameter): 
         case 'askingRate':
             return `$${value.toFixed(2)}/SF/year`;
         case 'availableSF':
-        case 'rba':
             return `${value.toLocaleString()} SF`;
         default:
             return value.toString();
@@ -200,8 +210,6 @@ export function getParameterDisplayName(parameter: ColorParameter): string {
             return 'Asking Rate';
         case 'availableSF':
             return 'Available SF';
-        case 'rba':
-            return 'Rentable Building Area';
         default:
             return parameter;
     }
@@ -323,8 +331,6 @@ function getPropertyValue(property: Property, parameter: ColorParameter): number
             return property.askingRate;
         case 'availableSF':
             return property.availableSF;
-        case 'rba':
-            return property.rba;
         default:
             return 0;
     }


### PR DESCRIPTION
Refactor heat map logic to remove RBA filter, implement cross-parameter coloring, and relocate the hover toggle for improved visualization and UX.

The heat map now uses a cross-parameter approach where the selected filter determines marker size, while the *opposite* parameter determines marker color. This allows users to visualize two property metrics simultaneously, providing a more comprehensive competitive analysis. For example, if 'availableSF' is selected, marker size reflects available square footage, and color reflects asking rate.

---
<a href="https://cursor.com/background-agent?bcId=bc-47e4f690-b195-4555-a766-50500d8b0a3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-47e4f690-b195-4555-a766-50500d8b0a3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

